### PR TITLE
Use NFS for shared folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.box     = "devstackbase-0.0.1"
   config.vm.box_url = "https://dl.dropboxusercontent.com/u/1355795/devstackbase-0.0.1.box"
+  config.vm.synced_folder ".", "/vagrant", :nfs => true
 
 
   # CONTROLLER CONFIG


### PR DESCRIPTION
The default Vagrant shared folders filesystem driver is not 100%
POSIX-compliant.  Things like hard links do not work at all.  Vagrant
can setup an NFS export automagically if host-only networking is
in use, so make use of it for greater compatibility.

Described in: https://docs.vagrantup.com/v2/synced-folders/nfs.html

Caveats: ignored completely in Windows, and requires superuser
access on the host system
